### PR TITLE
meson: no longer pass -Wl,--no-undefined explicitly

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -20,7 +20,6 @@ libcutf8_both = both_libraries(
         dependencies: libcutf8_deps,
         install: not meson.is_subproject(),
         link_args: [
-                '-Wl,--no-undefined',
                 '-Wl,--version-script=@0@'.format(libcutf8_symfile),
         ],
         link_depends: libcutf8_symfile,


### PR DESCRIPTION
to make it possible to build dbus-broker with clang and ASan/UBsan
on OSS-Fuzz (https://github.com/google/oss-fuzz/pull/7860) without
sed scripts.

-Wl,--no-undefined is still passed by meson by default unless -Db_lundef
is set to false explictily.

https://github.com/mesonbuild/meson/issues/764